### PR TITLE
do not throw error when re-deploying same commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
         this.log("SENTRY: Assigning commits...");
         this.sentryCliExec(
           "releases",
-          `set-commits ${releaseName} --auto --ignore-missing`
+          `set-commits ${releaseName} --auto --ignore-missing --ignore-empty`
         );
 
         this.log("SENTRY: Uploading source maps...");


### PR DESCRIPTION
Hi, some times on my CI/CD flow I deploy the same version (same commit) multiple times and sentry-cli seems to throw an error when we try to re-create a version with no commit changes. This flag ignores that and keeps sentry-cli from erroring allowing the deploy to continue.