### PR TITLE
allow set-commit to succeed even when the patchset is empty (--ignore…

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
         this.log("SENTRY: Assigning commits...");
         this.sentryCliExec(
           "releases",
-          `set-commits ${releaseName} --auto --ignore-missing`
+          `set-commits ${releaseName} --auto --ignore-missing --ignore-empty`
         );
 
         this.log("SENTRY: Uploading source maps...");


### PR DESCRIPTION
…-empty)

Since sentry-cli@1.67.0 `set-commits` command could be altered with --ignore-empty flag which allows sentry to proceed with an empty patchset.