### PR TITLE
feat: re-deploy with empty changeset

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
         this.log("SENTRY: Assigning commits...");
         this.sentryCliExec(
           "releases",
-          `set-commits ${releaseName} --auto --ignore-missing`
+          `set-commits ${releaseName} --auto --ignore-missing --ignore-empty`
         );
 
         this.log("SENTRY: Uploading source maps...");

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -184,7 +184,7 @@ describe('sentry-cli', function () {
           'node_modules',
           '.bin',
           'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project set-commits my-project@v1.0.0@1234567 --auto --ignore-missing`
+        )}  --auth-token my-auth-token releases --org my-org --project my-project set-commits my-project@v1.0.0@1234567 --auto --ignore-missing --ignore-empty`
       );
     });
 


### PR DESCRIPTION
Since sentry-cli@1.67.0 set-commits command could be altered with
--ignore-empty flag which allows sentry to proceed with an empty
patchset.