### PR TITLE
fix: locate `sentry-cli` when working with a mono-repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,16 @@ const { execSync } = require('child_process');
 const BasePlugin = require('ember-cli-deploy-plugin');
 const packageJson = require("./package.json");
 
+// Dynamically resolve `sentry-cli` location
+const sentryCliPackagePath = require.resolve("@sentry/cli/package.json");
+const { dir: sentryCliDirectory } = path.parse(sentryCliPackagePath);
+const sentryCliRelativeBinLocation =
+  require(sentryCliPackagePath).bin["sentry-cli"];
+const sentryCliAbsoluteBinLocation = path.join(
+  sentryCliDirectory,
+  sentryCliRelativeBinLocation
+);
+
 module.exports = {
   name: packageJson.name,
 
@@ -93,7 +103,7 @@ module.exports = {
 
         return this._exec(
           [
-            path.join("node_modules", ".bin", "sentry-cli"),
+            sentryCliAbsoluteBinLocation,
             url ? `--url ${url}` : "",
             `--auth-token ${authToken}`,
             command,

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -6,6 +6,9 @@ const sinon = require('sinon');
 const path = require('path');
 const Plugin = require('../../index');
 
+const { dir: PROJECT_ROOT } = path.parse(require.resolve('../../package.json'));
+const SENTRY_BIN_PATH = path.join(PROJECT_ROOT, 'node_modules/@sentry/cli/bin/sentry-cli');
+
 function setupSinon() {
   before(function () {
     this.sinon = sinon.createSandbox();
@@ -162,11 +165,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project new my-project@v1.0.0@1234567`
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project new my-project@v1.0.0@1234567`
       );
     });
 
@@ -180,11 +179,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project set-commits my-project@v1.0.0@1234567 --auto --ignore-missing`
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project set-commits my-project@v1.0.0@1234567 --auto --ignore-missing`
       );
     });
 
@@ -198,11 +193,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project files my-project@v1.0.0@1234567 upload-sourcemaps --rewrite ${path.join(
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project files my-project@v1.0.0@1234567 upload-sourcemaps --rewrite ${path.join(
           'my-dest-dir',
           'assets'
         )} `
@@ -221,11 +212,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project files my-project@v1.0.0@1234567 upload-sourcemaps --rewrite ${path.join(
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project files my-project@v1.0.0@1234567 upload-sourcemaps --rewrite ${path.join(
           'my-dest-dir',
           'assets'
         )} --url-prefix ~/assets`
@@ -242,11 +229,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project finalize my-project@v1.0.0@1234567`
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project finalize my-project@v1.0.0@1234567`
       );
     });
   });
@@ -262,11 +245,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project deploys my-project@v1.0.0@1234567 new -e my-production`
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project deploys my-project@v1.0.0@1234567 new -e my-production`
       );
     });
   });
@@ -282,11 +261,7 @@ describe('sentry-cli', function () {
 
       this.sinon.assert.calledWithExactly(
         stub,
-        `${path.join(
-          'node_modules',
-          '.bin',
-          'sentry-cli'
-        )}  --auth-token my-auth-token releases --org my-org --project my-project delete my-project@v1.0.0@1234567`
+        `${SENTRY_BIN_PATH}  --auth-token my-auth-token releases --org my-org --project my-project delete my-project@v1.0.0@1234567`
       );
     });
   });


### PR DESCRIPTION
The current approach to locating the `sentry-cli` executable makes the assumption that the package is installed in an Ember app at the root of the repository. This works fine most of the time, but breaks in a mono-repo where the actual `node_modules` directory might be above the current project in the directory structure.

This change dynamically locates the `sentry-cli` executable by:

1. Dynamically locating the `package.json` for the `@sentry/cli` package in a way that will work for both standard and mono-repo setups
2. Extracting the root of the `@sentry/cli` package from that path, which should be safe; the `package.json` will always be at the package root
3. Reading the `package.json` file for `@sentry/cli` to determine where the executable actually lives
4. Building an absolute path to the `sentry-cli` executable from the information that we've gathered

This makes the approach to locating `sentry-cli` resilient to changes in the directory structure for different types of apps