### PR TITLE
feat: allow for configurable `releaseName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Add plugin config to your `config/deploy.js`:
     orgName: 'sentry-org-name',
     authToken: process.env.SENTRY_AUTH_TOKEN,
     urlPrefix: '', // if you need prefix for Sentry to catch like ~/assets
+    releaseName: '', // optional; can be used to override the `${APP_NAME}@${REVISION_KEY}` pattern used for release naming
     // url: 'https://your-custom-sentry-server.test/` // in case of self-hosted server
   }
 }

--- a/index.js
+++ b/index.js
@@ -38,15 +38,20 @@ module.exports = {
           return context.deployTarget;
         },
 
+        releaseName(_context, pluginHelper) {
+          const appName = pluginHelper.readConfig("appName");
+          const revisionKey = pluginHelper.readConfig("revisionKey");
+
+          return `${appName}@${revisionKey}`;
+        },
+
         url: "",
       },
 
       requiredConfig: ["appName", "orgName", "authToken"],
 
       didPrepare() {
-        const releaseName = `${this.readConfig("appName")}@${this.readConfig(
-          "revisionKey"
-        )}`;
+        const releaseName = this.readConfig("releaseName");
         const assetsDir = this.readConfig("assetsDir");
         const urlPrefix = this.readConfig("urlPrefix")
           ? `--url-prefix ${this.readConfig("urlPrefix")}`
@@ -74,8 +79,7 @@ module.exports = {
       },
 
       didDeploy() {
-        const appName = this.readConfig("appName");
-        const releaseName = `${appName}@${this.readConfig("revisionKey")}`;
+        const releaseName = this.readConfig("releaseName");
         const environment = this.readConfig("environment");
 
         this.log("SENTRY: Deploying release...");
@@ -87,8 +91,7 @@ module.exports = {
       },
 
       didFail() {
-        const appName = this.readConfig("appName");
-        const releaseName = `${appName}@${this.readConfig("revisionKey")}`;
+        const releaseName = this.readConfig("releaseName");
 
         this.log("SENTRY: Deleting release...");
         this.sentryCliExec("releases", `delete "${releaseName}"`);

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -151,6 +151,15 @@ describe('sentry-cli', function () {
 
         assert.equal(plugin.readConfig('url'), '');
       });
+
+      it('releaseName', function() {
+        const plugin = Plugin.createDeployPlugin({ name: 'sentry-cli' });
+
+        plugin.beforeHook(this.context);
+        plugin.configure(this.context);
+
+        assert.equal(plugin.readConfig('releaseName'), 'my-project@v1.0.0@1234567');
+      })
     });
   });
 


### PR DESCRIPTION
This package currently generates a name for the release in Sentry that is not configurable by the user. If they want to use a release name that differs from the convention hard-coded into the package -- like, for example, using just the revision number -- that is currently impossible (aside from doing something to modify your dependencies).

This adds a `releaseName` configuration option that can be used to override the default name provided by the package. If left un-configured, the previous pattern is used. However, it can also be used to provide a different value that will be used to name the release in Sentry instead.

Originally I was using a [`yarn patch`](https://yarnpkg.com/cli/patch/#gatsby-focus-wrapper) to modify the `ember-cli-deploy-sentry-cli` code at installation time to change the `releaseName` pattern, but then realized it's computed in multiple locations. This gave me the idea to just make it configurable so that I don't have to modify the dependency and other people can also make easier changes to the release name if they want to, too.

In my case, I don't want the app name in the name of the release. We use _just_ the commit SHA as the release name in Sentry, which is impossible when the package has a hard opinion on prefixing the revision key with `$APP_NAME@` to create the release name.

Originally I wanted to just make the release name the revision key, which makes more sense to me since I would assume that people would want the revision key and the release name to be the same thing, but I wanted to avoid making a breaking change to the package; this gives users an escape hatch without forcing a breaking change.