### PR TITLE
fix: finalize release on activation

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,16 @@ module.exports = {
           `files "${releaseName}" upload-sourcemaps --rewrite ${assetsDir} ${urlPrefix}`
         );
 
+        this.log("SENTRY: Release published!...");
+      },
+
+      didActivate() {
+        const releaseName = `${this.readConfig("appName")}@${this.readConfig(
+          "revisionKey"
+        )}`;
+
         this.log("SENTRY: Finalizing release...");
         this.sentryCliExec("releases", `finalize "${releaseName}"`);
-
-        this.log("SENTRY: Release published!...");
       },
 
       didDeploy() {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -218,14 +218,16 @@ describe('sentry-cli', function () {
         )} --url-prefix ~/assets`
       );
     });
+  });
 
+  describe('didActivate', function() {
     it('saves release', function () {
       const plugin = Plugin.createDeployPlugin({ name: 'sentry-cli' });
       const stub = this.sinon.stub(plugin, '_exec');
 
       plugin.beforeHook(this.context);
       plugin.configure(this.context);
-      plugin.didPrepare();
+      plugin.didActivate();
 
       this.sinon.assert.calledWithExactly(
         stub,


### PR DESCRIPTION
Currently, releases are finalized in Sentry at the point that the deployment is made. This means that as soon as a release is deployed through `ember-cli-deploy`, it's considered to be the "production" version of your app.

`ember-cli-deploy` treats _creating_ a deployment and _activating_ a deployment as discrete actions. In our workflow, we deploy _every_ PR so that we can test our production app against it. When moving to this plugin, we now are marking random PRs are the production release of the app because the deployment intrinsically finalizes the release.

This PR moves the finalization logic to the `didActivate` hook of the plugin, which is only called when _activating_ a release. This allows us to resume deploying all of our PRs without them getting marked as the production release.

This will conflict with #21 due to the difference in looking up the `releaseName`; one or the other will have to be modified, assuming the other lands.